### PR TITLE
Font.setForceSelfPathDraw実行時に、familyName属性が誤って空になってしまうことがある問題を修正した。

### DIFF
--- a/LayerExDraw.cpp
+++ b/LayerExDraw.cpp
@@ -1,3 +1,12 @@
+#include <windows.h>
+#include <tp_stub.h>
+#include <gdiplus.h>
+#if _DEBUG
+#define _CRTDBG_MAP_ALLOC
+#include <crtdbg.h>
+#define new ::new(_NORMAL_BLOCK, __FILE__, __LINE__)
+#endif
+
 #pragma comment(lib, "gdiplus.lib")
 #include "ncbind/ncbind.hpp"
 #include "LayerExDraw.hpp"
@@ -286,7 +295,7 @@ FontInfo::clear()
  * フォントの指定
  */
 void
-FontInfo::setFamilyName(const tjs_char *familyName)
+FontInfo::setFamilyName(ttstr familyName)
 {
   propertyModified = true;
 
@@ -297,10 +306,10 @@ FontInfo::setFamilyName(const tjs_char *familyName)
     return;
   }
 
-	if (familyName) {
+  if (! familyName.IsEmpty()) {
 		clear();
 		if (privateFontCollection) {
-			fontFamily = new FontFamily(familyName, privateFontCollection);
+                  fontFamily = new FontFamily(familyName.c_str(), privateFontCollection);
 			if (fontFamily->IsAvailable()) {
 				this->familyName = familyName;
 				return;
@@ -308,7 +317,7 @@ FontInfo::setFamilyName(const tjs_char *familyName)
 				clear();
 			}
 		}
-		fontFamily = new FontFamily(familyName);
+		fontFamily = new FontFamily(familyName.c_str());
 		if (fontFamily->IsAvailable()) {
 			this->familyName = familyName;
 			return;
@@ -324,7 +333,7 @@ void
 FontInfo::setForceSelfPathDraw(bool state)
 {
   forceSelfPathDraw = state;
-  this->setFamilyName(familyName.c_str());
+  this->setFamilyName(familyName);
 }
 
 bool

--- a/LayerExDraw.hpp
+++ b/LayerExDraw.hpp
@@ -73,7 +73,7 @@ public:
 	 */
 	virtual ~FontInfo();
 
-	void setFamilyName(const tjs_char *familyName);
+	void setFamilyName(ttstr familyName);
 	const tjs_char *getFamilyName() { return familyName.c_str(); }
 	void setEmSize(REAL emSize) { this->emSize = emSize; propertyModified = true; }
 	REAL getEmSize() {  return emSize; }


### PR DESCRIPTION
ttstrをc_str() で更新して呼び出したルーチンの途中でもとのttstr自体を更新してしまうことによるバグ。
文字列呼び出しの引数自体を const tjs_char* ではなく ttstr で受け取るように変更して解決。