### PR TITLE
Font.setForceSelfPathDraw() 関数からの setFamilyname() 関数呼び出し時に、呼び出し元の変数の内…

### DIFF
--- a/LayerExDraw.cpp
+++ b/LayerExDraw.cpp
@@ -324,7 +324,8 @@ void
 FontInfo::setForceSelfPathDraw(bool state)
 {
   forceSelfPathDraw = state;
-  this->setFamilyName(familyName.c_str());
+  ttstr _name = familyName;
+  this->setFamilyName(_name.c_str());
 }
 
 bool


### PR DESCRIPTION
Font.setForceSelfPathDraw() 関数からの setFamilyname() 関数呼び出し時に、呼び出し元の変数の内容が更新され、呼び出し時の文字列ポインタが不定になってしまう問題を修正した。
修正を、Font.setForceSelfPathDraw() 関数内のみで完結させた。